### PR TITLE
style: left-align figure captions

### DIFF
--- a/theme/assets/css/captions.css
+++ b/theme/assets/css/captions.css
@@ -1,0 +1,30 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2026 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/*
+* Figure caption overrides.
+*
+* Loaded unminified, after `built/screen.css`, because the theme's CSS
+* minification pipeline is unavailable. `built/screen.css` inherits
+* `figcaption { text-align: center }` from the vendored Ghost Source theme
+* base; this file overrides it so the override survives a future rebuild
+* of `built/screen.css` from that base.
+*/
+figcaption {
+	text-align: left;
+}

--- a/theme/assets/css/captions.css
+++ b/theme/assets/css/captions.css
@@ -18,12 +18,6 @@
 
 /*
 * Figure caption overrides.
-*
-* Loaded unminified, after `built/screen.css`, because the theme's CSS
-* minification pipeline is unavailable. `built/screen.css` inherits
-* `figcaption { text-align: center }` from the vendored Ghost Source theme
-* base; this file overrides it so the override survives a future rebuild
-* of `built/screen.css` from that base.
 */
 figcaption {
 	text-align: left;

--- a/theme/default.hbs
+++ b/theme/default.hbs
@@ -30,6 +30,7 @@ limitations under the License.
 	<link rel="stylesheet" href="{{asset "css/themes/light/main.css"}}">
 	<link rel="stylesheet" href="{{asset "css/highlight.css"}}">
 	<link rel="stylesheet" href="{{asset "built/screen.css"}}">
+	<link rel="stylesheet" href="{{asset "css/captions.css"}}">
 	<style>
 		a {
 			text-decoration: none;


### PR DESCRIPTION
Left-align figure captions instead of center-aligning them (the default inherited from Ghost's `Source` theme).

Ships as a new standalone `theme/assets/css/captions.css`, linked in `default.hbs` right after `built/screen.css` — the same convention `footnotes.css` established in #8 — rather than editing the built stylesheet directly, since this repo can't currently rebuild `built/screen.css` from source on its own.

Closes #9.

## Test plan

- [x] Ran a local Ghost instance with this theme active and confirmed a real post's figure caption renders left-aligned under the image.